### PR TITLE
Don't stop on error when running stage tests

### DIFF
--- a/run-stage
+++ b/run-stage
@@ -12,4 +12,4 @@ cd $PWD/mozilla-central/testing/tps || exit 1
 
 # xvfb-run - uses DISPLAY=:99 (by default)
 #xvfb-run runtps --debug --binary="${BINARY}" 
-MOZ_HEADLESS=1 runtps --debug --stop-on-error --binary="${BINARY}" --configfile=$CFGDIR/stage-config.json
+MOZ_HEADLESS=1 runtps --debug --binary="${BINARY}" --configfile=$CFGDIR/stage-config.json


### PR DESCRIPTION
This makes it hard to know how long ago things began failing when going back and fixing things, and often one failure won't lead to others (although sometimes it will – cleanup failures do, certainly).