### PR TITLE
fix: overwrite log if exists

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
   }
   post {
     always {
-      sh 'gzip tps.log'
+      sh 'gzip -f tps.log'
     } 
     success {
       emailext(


### PR DESCRIPTION
r? @karlht 
tested by running STAGE manually twice and indeed log is overwritten.

Closes #13 